### PR TITLE
Added missing .Disable() for detouring hook

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -278,6 +278,7 @@ GMOD_MODULE_OPEN()
 
 GMOD_MODULE_CLOSE()
 {
+	detour_BroadcastVoiceData.Disable();
 	detour_BroadcastVoiceData.Destroy();
 
 	for (auto& p : g_eightbit->afflictedPlayers) {


### PR DESCRIPTION
Detouring hooks that were enabled needs to be disabled so they are destroyed properly. I don't remember exactly why, but Destroy() does not disables hook properly.