### PR TITLE
feat: Add automated release creation and update CI runners

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -64,13 +64,14 @@ jobs:
             - name: Checkout main repo
               uses: actions/checkout@v4
 
-            - name: Checkout garrysmod_common submodule
+            - name: Checkout garrysmod_common (pinned)
               uses: actions/checkout@v4
               with:
                   repository: danielga/garrysmod_common
-                  ref: x86-64-support-sourcesdk
-                  submodules: recursive
+                  ref: 63bd98014b342d4250ce365ad856f9132ee7c11e
                   path: garrysmod_common
+                  fetch-depth: 1
+                  submodules: recursive
 
             - name: Install Premake
               run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,13 +17,14 @@ jobs:
             - name: Checkout main repo
               uses: actions/checkout@v4
 
-            - name: Checkout garrysmod_common submodule
+            - name: Checkout garrysmod_common (pinned)
               uses: actions/checkout@v4
               with:
-                  repository: danielga/garrysmod_common
-                  ref: x86-64-support-sourcesdk
-                  submodules: recursive
-                  path: garrysmod_common
+                repository: danielga/garrysmod_common
+                ref: 63bd98014b342d4250ce365ad856f9132ee7c11e
+                path: garrysmod_common
+                fetch-depth: 1
+                submodules: recursive
 
             - name: Install Premake & dépendances
               run: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,77 +1,163 @@
 name: Build
 
 on:
-  push:
-    branches: [ master ]
-  workflow_dispatch:
+    push:
+        branches:
+            - master
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    packages: write
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        repository: danielga/garrysmod_common
-        ref: x86-64-support-sourcesdk
-        path: 'garrysmod_common'
-    - name: Install Premake
-      run: |
-        wget https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-linux.tar.gz -O premake.tar.gz
-        tar -xvf premake.tar.gz
-        chmod +x premake5
-        sudo cp premake5 /usr/bin
-        sudo apt-get update
-        sudo apt-get install g++-multilib
-        gcc --version
-    - name: Generate Project
-      run: |
-        premake5 --gmcommon=garrysmod_common gmake
-    - name: Make
-      run: |
-        cd projects/linux/gmake
-        make
-        make config=releasewithsymbols_x86_64
-    - uses: actions/upload-artifact@v4
-      with:
-        name: gmsv_eightbit_linux.dll
-        path: projects/linux/gmake/x86/ReleaseWithSymbols/gmsv_eightbit_linux.dll
-    - uses: actions/upload-artifact@v4
-      with:
-        name: gmsv_eightbit_linux64.dll
-        path: projects/linux/gmake/x86_64/ReleaseWithSymbols/gmsv_eightbit_linux64.dll
-  build-windows:
-    runs-on: windows-2019
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        repository: danielga/garrysmod_common
-        path: 'garrysmod_common'
-        ref: x86-64-support-sourcesdk
-    - name: Install Premake
-      run: |
-         curl -L https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-windows.zip -o premake.zip
-         tar -xf premake.zip
-    - name: Generate Project
-      run: |
-        ./premake5.exe --gmcommon=garrysmod_common vs2019
-    - name: Build
-      run: |
-        cd projects/windows/vs2019
-        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" /p:Configuration=ReleaseWithSymbols /p:Platform=Win32 eightbit.sln
-    - uses: actions/upload-artifact@v4
-      with:
-        name: gmsv_eightbit_windows.dll
-        path: projects/windows/vs2019/x86/ReleaseWithSymbols/gmsv_eightbit_win32.dll
-    - name: Build 64
-      run: |
-        cd projects/windows/vs2019
-        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" /p:Configuration=ReleaseWithSymbols /p:Platform=x64 eightbit.sln
-    - uses: actions/upload-artifact@v4
-      with:
-        name: gmsv_eightbit_win64.dll
-        path: projects/windows/vs2019/x86_64/ReleaseWithSymbols/gmsv_eightbit_win64.dll
+    build-linux:
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Checkout main repo
+              uses: actions/checkout@v4
 
+            - name: Checkout garrysmod_common submodule
+              uses: actions/checkout@v4
+              with:
+                  repository: danielga/garrysmod_common
+                  ref: x86-64-support-sourcesdk
+                  submodules: recursive
+                  path: garrysmod_common
+
+            - name: Install Premake & dépendances
+              run: |
+                  wget https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-linux.tar.gz -O premake.tar.gz
+                  tar -xzf premake.tar.gz
+                  chmod +x premake5
+                  sudo mv premake5 /usr/local/bin/
+                  sudo apt-get update
+                  sudo apt-get install -y g++-multilib
+                  gcc --version
+
+            - name: Génération du projet avec Premake
+              run: |
+                  premake5 --gmcommon=garrysmod_common gmake
+
+            - name: Compilation Linux
+              run: |
+                  cd projects/linux/gmake
+                  make
+                  make config=releasewithsymbols_x86_64
+
+            - name: Upload artifact Linux x86
+              uses: actions/upload-artifact@v4
+              with:
+                  name: gmsv_eightbit_linux.dll
+                  path: projects/linux/gmake/x86/ReleaseWithSymbols/gmsv_eightbit_linux.dll
+
+            - name: Upload artifact Linux x86_64
+              uses: actions/upload-artifact@v4
+              with:
+                  name: gmsv_eightbit_linux64.dll
+                  path: projects/linux/gmake/x86_64/ReleaseWithSymbols/gmsv_eightbit_linux64.dll
+
+    build-windows:
+        runs-on: windows-2022
+        steps:
+            - name: Checkout main repo
+              uses: actions/checkout@v4
+
+            - name: Checkout garrysmod_common submodule
+              uses: actions/checkout@v4
+              with:
+                  repository: danielga/garrysmod_common
+                  ref: x86-64-support-sourcesdk
+                  submodules: recursive
+                  path: garrysmod_common
+
+            - name: Install Premake
+              run: |
+                  curl -L https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-windows.zip -o premake.zip
+                  Expand-Archive premake.zip -DestinationPath premake
+
+            - name: Add Premake to PATH
+              shell: pwsh
+              run: |
+                  "$Env:GITHUB_WORKSPACE\premake" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
+            - name: Generate Project with Premake
+              shell: pwsh
+              run: premake5.exe --gmcommon=garrysmod_common vs2022
+
+            - name: Build Win32
+              shell: pwsh
+              run: |
+                  cd projects/windows/vs2022
+                  $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+                  & $msbuild eightbit.sln /p:Configuration=ReleaseWithSymbols /p:Platform=Win32
+
+            - name: Upload artifact Windows x86
+              uses: actions/upload-artifact@v4
+              with:
+                  name: gmsv_eightbit_win32.dll
+                  path: projects/windows/vs2022/x86/ReleaseWithSymbols/gmsv_eightbit_win32.dll
+
+            - name: Build x64
+              shell: pwsh
+              run: |
+                  cd projects/windows/vs2022
+                  $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+                  & $msbuild eightbit.sln /p:Configuration=ReleaseWithSymbols /p:Platform=x64
+
+            - name: Upload artifact Windows x64
+              uses: actions/upload-artifact@v4
+              with:
+                  name: gmsv_eightbit_win64.dll
+                  path: projects/windows/vs2022/x86_64/ReleaseWithSymbols/gmsv_eightbit_win64.dll
+
+    release:
+        name: Publish Release
+        needs:
+            - build-linux
+            - build-windows
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/master'
+        permissions:
+            contents: write
+        steps:
+            - name: Download Linux 32‑bit DLL
+              uses: actions/download-artifact@v4
+              with:
+                  name: gmsv_eightbit_linux.dll
+                  path: release/linux32
+
+            - name: Download Linux 64‑bit DLL
+              uses: actions/download-artifact@v4
+              with:
+                  name: gmsv_eightbit_linux64.dll
+                  path: release/linux64
+
+            - name: Download Windows 32‑bit DLL
+              uses: actions/download-artifact@v4
+              with:
+                  name: gmsv_eightbit_win32.dll
+                  path: release/win32
+
+            - name: Download Windows 64‑bit DLL
+              uses: actions/download-artifact@v4
+              with:
+                  name: gmsv_eightbit_win64.dll
+                  path: release/win64
+
+            - name: Create Release with Assets
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: v${{ github.run_number }}
+                  name: v${{ github.run_number }}
+                  body: |
+                      Voice Recorder Module - Build ${{ github.run_number }}
+
+                      Download the appropriate DLL for your platform and place it in garrysmod/lua/bin/
+                  files: |
+                      release/linux32/gmsv_eightbit_linux.dll
+                      release/linux64/gmsv_eightbit_linux64.dll
+                      release/win32/gmsv_eightbit_win32.dll
+                      release/win64/gmsv_eightbit_win64.dll
+                  draft: false
+                  prerelease: false


### PR DESCRIPTION
## Changes

### Automated Release Creation
- Added release job that creates GitHub releases with compiled binaries
- Releases provide permanent downloads (GitHub artifacts expire after 90 days)
- Automatic versioning using build numbers
- Includes installation instructions in release notes

### CI Runner Updates
- Updated Linux runner: ubuntu-20.04 → ubuntu-22.04
- Updated Windows runner: windows-2019 → windows-2022
- Updated GitHub Actions to latest versions (checkout@v4, upload-artifact@v4)
- Fixed MSBuild path detection using vswhere for better compatibility

### Release Workflow
- Only triggers on master branch pushes
- Downloads all build artifacts (Linux x86/x64, Windows x86/x64)
- Creates single release with all platform binaries
- Provides clear download instructions for users

## Why This Matters
GitHub artifacts expire after 90 days, making old builds inaccessible. This change ensures users can always download working binaries from any build. Also keeps the CI environment up to date since GitHub deprecated the old runner versions.

The release process is fully automated - push to master and get a tagged release with all binaries ready for